### PR TITLE
Reuse handlers across proxies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,14 @@
 const rdf = require('@rdfjs/data-model')
 
+const handler = {
+  apply: (target, thisArg, args) => target(args[0]),
+  get: (target, property) => target(property)
+}
+
 function namespace (baseIRI, { factory = rdf } = {}) {
   const builder = term => factory.namedNode(`${baseIRI}${term.raw || term}`)
 
-  if (!Proxy) {
-    return builder
-  }
-
-  return new Proxy(() => {}, {
-    apply: (target, thisArg, args) => builder(args[0]),
-    get: (target, property) => builder(property)
-  })
+  return typeof Proxy === 'undefined' ? builder : new Proxy(builder, handler)
 }
 
 module.exports = namespace

--- a/test/test.js
+++ b/test/test.js
@@ -57,7 +57,7 @@ describe('namespace', () => {
     it('should return undefined if the JavaScript engine doesn\'t support Proxy', () => {
       const ProxyBackup = global.Proxy
 
-      global.Proxy = undefined
+      delete global.Proxy
 
       const schema = namespace('http://schema.org/')
       const term = schema.hasPart


### PR DESCRIPTION
No need to create new handlers every time.

Also fixes the check for `Proxy` support, which is currently broken.